### PR TITLE
Add manual workflow triggers

### DIFF
--- a/.github/workflows/devdojo.yaml
+++ b/.github/workflows/devdojo.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Runs every day
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   update-readme-with-blog:

--- a/.github/workflows/devto.yaml
+++ b/.github/workflows/devto.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Runs every day
     - cron: '30 0 * * *'
+  workflow_dispatch:
 
 jobs:
   update-readme-with-blog:


### PR DESCRIPTION
This PR adds the `workflow_dispatch` key to each workflow file.
This will enable [manual triggers](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) to trigger workflows manually. Useful in case you don't want to wait for an action to run. 🙂